### PR TITLE
feat(autocomplete): update to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "algoliasearch": "^3.35.1",
     "algoliasearch-helper": "^3.2.2",
     "angular": "1.4.7",
-    "autocomplete.js": "^0.26.0",
+    "autocomplete.js": "^0.38.0",
     "babel-core": "^6.11.4",
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-react-constant-elements": "^6.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -156,9 +156,10 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
-autocomplete.js@^0.26.0:
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/autocomplete.js/-/autocomplete.js-0.26.0.tgz#a2a48f4145670e781542679f1920c9e86d534640"
+autocomplete.js@^0.38.0:
+  version "0.38.0"
+  resolved "https://registry.yarnpkg.com/autocomplete.js/-/autocomplete.js-0.38.0.tgz#9d49c2f4788fa23960275a6422ca78b310c01ef8"
+  integrity sha512-xZlqbg0LN9D1cZd4TkPJmir/Bq0+xXnp35X6i87yU2dD2wYv9E7pVU1+QKu0PbBVV2dShppwlKGMsfCYQD9OtA==
   dependencies:
     immediate "^3.2.3"
 


### PR DESCRIPTION
notably:
- multiple hits sources will only do one request
- user agent works for algoliasearch@3.33+
- misc fixes

DX-1280