### PR TITLE
feat: update instantsearch version

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,5 @@
 module.exports = {
   $: require('jquery'),
-  // we ask for the non-builded version of instantsearch.js to avoid
-  // duplication of algoliasearch, algoliasearchHelper and hogan modules
-  // that's why we also need some webpack configuration and modules here
   instantsearch: require('instantsearch.js/dist/instantsearch.production.min.js'),
   algoliasearch: require('algoliasearch'),
   algoliasearchHelper: require('algoliasearch-helper'),

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "babel-preset-stage-2": "^6.11.0",
     "file-loader": "^0.10.1",
     "hogan.js": "^3.0.2",
-    "instantsearch.js": "^4.29.1",
+    "instantsearch.js": "^4.30.0",
     "jquery": "^2.2.0",
     "jquery-ui": "1.10.5",
     "json": "^9.0.4",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "resolutions": {
     "algoliasearch": "3.35.1",
-    "algoliasearch-helper": "3.2.2",
+    "algoliasearch-helper": "3.5.5",
     "events": "1.1.1",
     "preact-compat": "3.18.2",
     "lodash": "4.17.10",
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "algoliasearch": "^3.35.1",
-    "algoliasearch-helper": "^3.2.2",
+    "algoliasearch-helper": "^3.5.5",
     "angular": "1.4.7",
     "autocomplete.js": "^0.38.0",
     "babel-core": "^6.11.4",
@@ -36,7 +36,7 @@
     "babel-preset-stage-2": "^6.11.0",
     "file-loader": "^0.10.1",
     "hogan.js": "^3.0.2",
-    "instantsearch.js": "^4.7.2",
+    "instantsearch.js": "^4.29.1",
     "jquery": "^2.2.0",
     "jquery-ui": "1.10.5",
     "json": "^9.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1456,10 +1456,10 @@ ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
-instantsearch.js@^4.29.1:
-  version "4.29.1"
-  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.29.1.tgz#7bacd0cf399aaf70de6d536e37a438c54b9e80e1"
-  integrity sha512-dSmF/vkP9mrvW1DgRuB3rrkEz6ewpYtobCX99EXa6JSvnXbdCEfuSiTORHGOC9He7q5i1rutM5WslJYPw4fNlw==
+instantsearch.js@^4.30.0:
+  version "4.30.0"
+  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.30.0.tgz#84d45f28ea1735fce14da94dc6a2128a7140e748"
+  integrity sha512-UTtDbAqaw9l0Zs+L/veYwtllqeeqc8WyPcXWrQxnLa+zAgS+9wj+kjKsLHlQF13EBuSp5szPoOQWugKE6Yoe2w==
   dependencies:
     "@types/google.maps" "^3.45.3"
     "@types/hogan.js" "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,20 @@
 # yarn lockfile v1
 
 
-"@types/googlemaps@^3.39.6":
-  version "3.39.13"
-  resolved "https://registry.yarnpkg.com/@types/googlemaps/-/googlemaps-3.39.13.tgz#a2649ac618cb15bd04ad8700c41693c8c1f90e21"
-  integrity sha512-R/k5WKe8zQHo9oFRINuX/1haKYRkKEfItnBGrSjspbXXITakRdsj6daQIdL1+Pt84lnzduWurxNA5k0fgPMQUg==
+"@types/google.maps@^3.45.3":
+  version "3.45.6"
+  resolved "https://registry.yarnpkg.com/@types/google.maps/-/google.maps-3.45.6.tgz#441a7bc76424243b307596fc8d282a435a979ebd"
+  integrity sha512-BzGzxs8UXFxeP8uN/0nRgGbsbpYQxSCKsv/7S8OitU7wwhfFcqQSm5aAcL1nbwueMiJ/VVmIZKPq69s0kX5W+Q==
+
+"@types/hogan.js@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/hogan.js/-/hogan.js-3.0.1.tgz#64c54407b30da359763e14877f5702b8ae85d61c"
+  integrity sha512-D03i/2OY7kGyMq9wdQ7oD8roE49z/ZCZThe/nbahtvuqCNZY9T2MfedOWyeBdbEpY2W8Gnh/dyJLdFtUCOkYbg==
+
+"@types/qs@^6.5.3":
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
+  integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
 abbrev@1:
   version "1.1.1"
@@ -26,10 +36,10 @@ ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-algoliasearch-helper@3.2.2, algoliasearch-helper@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.2.2.tgz#12451c8e368935348453c8879785b20e1788c33c"
-  integrity sha512-/3XvE33R+gQKaiPdy3nmHYqhF8hqIu8xnlOicVxb1fD6uMFmxW8rGLzzrRfsPfxgAfm+c1NslLb3TzQVIB8aVA==
+algoliasearch-helper@3.5.5, algoliasearch-helper@^3.5.5:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.5.5.tgz#05263869d3c8a7292278d7e49630f52520f204d7"
+  integrity sha512-JDH14gMpSj8UzEaKwVkrqKOeAOyK0dDWsFlKvWhk0Xl5yw9FyafYf1xZPb4uSXaPBAFQtUouFlR1Zt68BCY0/w==
   dependencies:
     events "^1.1.1"
 
@@ -1446,19 +1456,20 @@ ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
-instantsearch.js@^4.7.2:
-  version "4.7.2"
-  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.7.2.tgz#4b8932e623c52231f98711279d0c3967db75ceba"
-  integrity sha512-QnxJpu4SQeKVrfFiMWV33HuQ7arY0lzHeIhCH6MpFzOow1k3VXVEzF53j8nLKH2D6cdwaGSEsZhJMZn4OdIP+A==
+instantsearch.js@^4.29.1:
+  version "4.29.1"
+  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.29.1.tgz#7bacd0cf399aaf70de6d536e37a438c54b9e80e1"
+  integrity sha512-dSmF/vkP9mrvW1DgRuB3rrkEz6ewpYtobCX99EXa6JSvnXbdCEfuSiTORHGOC9He7q5i1rutM5WslJYPw4fNlw==
   dependencies:
-    "@types/googlemaps" "^3.39.6"
-    algoliasearch-helper "^3.2.2"
+    "@types/google.maps" "^3.45.3"
+    "@types/hogan.js" "^3.0.0"
+    "@types/qs" "^6.5.3"
+    algoliasearch-helper "^3.5.5"
     classnames "^2.2.5"
     events "^1.1.0"
     hogan.js "^3.0.2"
     preact "^10.0.0"
-    prop-types "^15.5.10"
-    qs "^6.5.1"
+    qs "^6.5.1 < 6.10"
 
 interpret@^0.6.4:
   version "0.6.6"
@@ -2089,7 +2100,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.8:
+prop-types@^15.5.8:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -2109,7 +2120,7 @@ punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-qs@6.5.2, qs@^6.5.1, qs@~6.4.0:
+qs@6.5.2, "qs@^6.5.1 < 6.10", qs@~6.4.0:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 


### PR DESCRIPTION
Among other things, this adds:
- insights middleware
- dynamic widgets
- many fixes
- middleware no longer experimental
- access to renderState outside of widgets
- detected by metadata scraper
- canRefine available in connectors
- sendEvent works with hitsPerPage > 20